### PR TITLE
Fix false reprice alerts for multi-copy listings

### DIFF
--- a/poller/sale_inference_engine.py
+++ b/poller/sale_inference_engine.py
@@ -16,7 +16,7 @@ Rules:
    The poller prefers a live account-filter search + fetch (`listing.account.online` on another of
    their listings); if that probe fails, it falls back to `sellerOnline` from the prior ladder fetch.
 5. Same fingerprint + same seller still listed but listed price changed -> repriced
-   (not a sale; distinguishes relist/reprice from churn).
+   (not a sale; only when that pair maps to exactly one listing on both polls).
 6. Same fingerprint offered by 2+ different sellers in one fetch -> multi-party contention signal.
 7. New (fingerprint, seller) pairs vs previous poll -> fresh supply / new listing rows this cycle.
 """
@@ -287,6 +287,22 @@ def _meta_for(
         if s.get("fingerprint") == fingerprint and str(s.get("seller") or "") == seller:
             return s
     return None
+
+
+def _signal_pair_counts(signals: list[dict[str, Any]]) -> dict[tuple[str, str], int]:
+    counts: dict[tuple[str, str], int] = {}
+    for s in signals:
+        fp = str(s.get("fingerprint") or "")
+        seller = str(s.get("seller") or "")
+        if not fp or not seller:
+            continue
+        key = (fp, seller)
+        count_hint = s.get("signalCount")
+        if isinstance(count_hint, int) and count_hint > 0:
+            counts[key] = max(counts.get(key, 0), int(count_hint))
+            continue
+        counts[key] = counts.get(key, 0) + 1
+    return counts
 
 
 def _as_float(x: Any) -> float | None:
@@ -1061,7 +1077,13 @@ def evaluate_listing_transition(
             )
 
     # --- Rule 5: same listing identity, listed price changed (reprice / note change) ---
+    prev_pair_counts = _signal_pair_counts(prev_signals)
+    curr_pair_counts = _signal_pair_counts(curr_signals)
     for fp, seller in prev_keys & curr_keys:
+        if prev_pair_counts.get((fp, seller), 0) != 1 or curr_pair_counts.get((fp, seller), 0) != 1:
+            # Multiple listings share this (fingerprint, seller) pair, so listing identity is ambiguous.
+            # Skip repricing to avoid false positives from switching between distinct copies.
+            continue
         pm = _meta_for(prev_signals, fp, seller)
         cm = _meta_for(curr_signals, fp, seller)
         if not pm or not cm:

--- a/poller/test_sale_inference_engine.py
+++ b/poller/test_sale_inference_engine.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+
+from poller.sale_inference_engine import evaluate_listing_transition
+
+
+class SaleInferenceEngineRepriceTests(unittest.TestCase):
+    def test_reprice_skipped_when_pair_has_multiple_listings(self) -> None:
+        prev_signals = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "isInstant": False,
+                "mirrorEquiv": 4.0,
+                "priceAmount": 4.0,
+                "priceCurrency": "mirror",
+                "signalCount": 2,
+            }
+        ]
+        curr_signals = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "isInstant": False,
+                "mirrorEquiv": 3.9,
+                "priceAmount": 3.9,
+                "priceCurrency": "mirror",
+            },
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "isInstant": False,
+                "mirrorEquiv": 4.0,
+                "priceAmount": 4.0,
+                "priceCurrency": "mirror",
+            },
+        ]
+
+        result, _, _, _ = evaluate_listing_transition(
+            item_key="Brightbeak",
+            cycle=101,
+            prev_signals=prev_signals,
+            curr_signals=curr_signals,
+            pending_instant=[],
+            pending_online=[],
+        )
+
+        self.assertEqual(result.reprice_same_seller, 0)
+        self.assertFalse(any(str(ev.get("rule") or "") == "reprice_same_seller" for ev in result.events))
+
+    def test_reprice_detected_for_unambiguous_single_listing(self) -> None:
+        prev_signals = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "isInstant": False,
+                "mirrorEquiv": 4.0,
+                "priceAmount": 4.0,
+                "priceCurrency": "mirror",
+            }
+        ]
+        curr_signals = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "isInstant": False,
+                "mirrorEquiv": 3.9,
+                "priceAmount": 3.9,
+                "priceCurrency": "mirror",
+            }
+        ]
+
+        result, _, _, _ = evaluate_listing_transition(
+            item_key="Brightbeak",
+            cycle=102,
+            prev_signals=prev_signals,
+            curr_signals=curr_signals,
+            pending_instant=[],
+            pending_online=[],
+        )
+
+        self.assertEqual(result.reprice_same_seller, 1)
+        self.assertTrue(any(str(ev.get("rule") or "") == "reprice_same_seller" for ev in result.events))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/storage/db.py
+++ b/storage/db.py
@@ -24,6 +24,7 @@ from .schema import (
     migration_013_inference_pending_jitter_grace,
     migration_014_new_item_alert_cooldown,
     migration_015_account_ban_alert_cooldown,
+    migration_016_inference_signal_count,
 )
 
 
@@ -129,6 +130,7 @@ class Database:
             (13, migration_013_inference_pending_jitter_grace()),
             (14, migration_014_new_item_alert_cooldown()),
             (15, migration_015_account_ban_alert_cooldown()),
+            (16, migration_016_inference_signal_count()),
         ]
 
         for version, sql in migrations:
@@ -150,6 +152,8 @@ class Database:
                 self._migration_012_item_variants_image_filter(con)
             elif version == 13:
                 self._migration_013_inference_pending_jitter_grace(con)
+            elif version == 16:
+                self._migration_016_inference_signal_count(con)
             elif sql.strip():
                 con.executescript(sql)
             con.execute(
@@ -406,7 +410,21 @@ class Database:
                 "ALTER TABLE inference_state_pending ADD COLUMN jitter_grace_polls INTEGER NOT NULL DEFAULT 0"
             )
 
+    def _migration_016_inference_signal_count(self, con: sqlite3.Connection) -> None:
+        sig_cols = {
+            str((r["name"] if isinstance(r, sqlite3.Row) else r[1]))
+            for r in con.execute("PRAGMA table_info(inference_state_signals)").fetchall()
+        }
+        if "signal_count" not in sig_cols:
+            con.execute("ALTER TABLE inference_state_signals ADD COLUMN signal_count INTEGER NOT NULL DEFAULT 1")
+        con.execute(
+            """
+            UPDATE inference_state_signals
+               SET signal_count = 1
+             WHERE signal_count IS NULL OR signal_count < 1
+            """
+        )
+
 
 def execute_many(con: sqlite3.Connection, sql: str, rows: Iterable[tuple]) -> None:
     con.executemany(sql, list(rows))
-

--- a/storage/repos.py
+++ b/storage/repos.py
@@ -486,7 +486,7 @@ class InferenceStateRepo:
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
         sig_rows = self._con.execute(
             """
-            SELECT fingerprint, seller, is_instant, mirror_equiv, price_amount, price_currency, seller_online
+            SELECT fingerprint, seller, is_instant, mirror_equiv, price_amount, price_currency, seller_online, signal_count
             FROM inference_state_signals
             WHERE item_variant_id = ?
             """,
@@ -509,6 +509,7 @@ class InferenceStateRepo:
                 "mirrorEquiv": (float(r["mirror_equiv"]) if r["mirror_equiv"] is not None else None),
                 "priceAmount": (float(r["price_amount"]) if r["price_amount"] is not None else None),
                 "priceCurrency": (str(r["price_currency"]) if r["price_currency"] is not None else None),
+                "signalCount": max(1, int(r["signal_count"] or 1)),
             }
             for r in sig_rows
         ]
@@ -545,6 +546,14 @@ class InferenceStateRepo:
         self._con.execute("DELETE FROM inference_state_pending WHERE item_variant_id = ?", (item_variant_id,))
 
         sig_payload: list[tuple] = []
+        key_counts: dict[tuple[str, str], int] = {}
+        for s in curr_signals:
+            fp = str(s.get("fingerprint") or "")
+            seller = str(s.get("seller") or "")
+            if not fp or not seller:
+                continue
+            key = (fp, seller)
+            key_counts[key] = key_counts.get(key, 0) + 1
         seen_sig: set[tuple[str, str]] = set()
         for s in curr_signals:
             fp = str(s.get("fingerprint") or "")
@@ -553,7 +562,7 @@ class InferenceStateRepo:
                 continue
             key = (fp, seller)
             if key in seen_sig:
-                # Same seller can list multiple identical items; state tracks the (fingerprint,seller) pair.
+                # Same seller can list multiple identical items; persist one representative plus signal_count.
                 continue
             seen_sig.add(key)
             sig_payload.append(
@@ -565,6 +574,7 @@ class InferenceStateRepo:
                     s.get("mirrorEquiv"),
                     s.get("priceAmount"),
                     (str(s.get("priceCurrency") or "").strip().lower() or None),
+                    max(1, int(key_counts.get(key, 1))),
                     cycle,
                     1 if bool(s.get("sellerOnline")) else 0,
                 )
@@ -572,8 +582,8 @@ class InferenceStateRepo:
         self._con.executemany(
             """
             INSERT INTO inference_state_signals(
-              item_variant_id, fingerprint, seller, is_instant, mirror_equiv, price_amount, price_currency, last_seen_cycle, seller_online
-            ) VALUES (?,?,?,?,?,?,?,?,?)
+              item_variant_id, fingerprint, seller, is_instant, mirror_equiv, price_amount, price_currency, signal_count, last_seen_cycle, seller_online
+            ) VALUES (?,?,?,?,?,?,?,?,?,?)
             """,
             sig_payload,
         )
@@ -1081,4 +1091,3 @@ class PriceAlertCooldownRepo:
             """,
             (int(item_variant_id), int(last_alert_cycle), float(last_alert_low_mirror), str(updated_at_utc)),
         )
-

--- a/storage/schema.py
+++ b/storage/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 
 def migration_001_initial() -> str:
@@ -131,6 +131,7 @@ CREATE TABLE IF NOT EXISTS inference_state_signals (
   seller TEXT NOT NULL,
   is_instant INTEGER NOT NULL DEFAULT 0,
   mirror_equiv REAL,
+  signal_count INTEGER NOT NULL DEFAULT 1,
   last_seen_cycle INTEGER,
   UNIQUE(item_variant_id, fingerprint, seller)
 );
@@ -319,3 +320,7 @@ CREATE TABLE IF NOT EXISTS account_ban_alert_cooldown (
 CREATE INDEX IF NOT EXISTS idx_inference_events_rule ON inference_events(rule);
 """
 
+
+def migration_016_inference_signal_count() -> str:
+    """Applied via a Python idempotent migration in `storage/db.py`."""
+    return ""


### PR DESCRIPTION
Address false reprice alerts caused by multiple identical listings from the same seller. Implemented a mechanism to track signal counts per (fingerprint, seller) pair, ensuring repricing only occurs when the pair maps to a single listing. Added necessary database schema changes and regression tests to validate the fix.