### PR TITLE
fix(poller): defer rule 4b non-instant online sale credit to avoid false positives

### DIFF
--- a/poller/poll_item_prices.py
+++ b/poller/poll_item_prices.py
@@ -790,6 +790,25 @@ def load_inference_fetch_jitter_grace_polls(storage: StorageService) -> int:
     return max(0, min(10, int(raw)))
 
 
+def load_inference_non_instant_online_grace_polls(storage: StorageService) -> int:
+    """
+    Defer crediting a non-instant "seller was online" vanish (rule 4b) for this many poll cycles.
+
+    PoE trade's `account.online` flag can lag a real logout, so a listing that disappears right as
+    its seller goes offline can look "online" for one more cycle. Holding the credit for a short
+    grace window lets a quick same-seller reappearance resolve as fetch jitter instead of a
+    sale + revert alert pair.
+
+    Config key: app_config.market.inference_non_instant_online_grace_polls (default 1)
+    """
+    try:
+        data = storage.get_config(key="market") or {}
+        raw = int(float(data.get("inference_non_instant_online_grace_polls", 1)))
+    except Exception:
+        raw = 1
+    return max(0, min(10, int(raw)))
+
+
 def load_inference_truncated_instant_vanish_max_above_floor_pct(storage: StorageService) -> float:
     """
     When the trade search returns more IDs than we fetch, only infer instant vanishes for listings
@@ -3029,6 +3048,7 @@ def run_cycle(
                 storage
             ),
             fetch_jitter_grace_polls=load_inference_fetch_jitter_grace_polls(storage),
+            non_instant_online_grace_polls=load_inference_non_instant_online_grace_polls(storage),
         )
         (
             xfer,

--- a/poller/sale_inference_engine.py
+++ b/poller/sale_inference_engine.py
@@ -15,6 +15,8 @@ Rules:
 4b. Non-instant listing gone while seller appears online -> likely sold (pending relist can undo).
    The poller prefers a live account-filter search + fetch (`listing.account.online` on another of
    their listings); if that probe fails, it falls back to `sellerOnline` from the prior ladder fetch.
+   PoE's online flag can lag a real logout, so this credit defers for a short grace window (see
+   `non_instant_online_grace_polls`) before counting, to avoid alerting on a seller who just logged off.
 5. Same fingerprint + same seller still listed but listed price changed -> repriced
    (not a sale; only when that pair maps to exactly one listing on both polls).
 6. Same fingerprint offered by 2+ different sellers in one fetch -> multi-party contention signal.
@@ -635,6 +637,7 @@ def evaluate_listing_transition(
     truncated_instant_vanish_max_above_floor_pct: float = 25.0,
     truncated_instant_vanish_max_above_floor_mirrors: float = 0.08,
     fetch_jitter_grace_polls: int = 2,
+    non_instant_online_grace_polls: int = 1,
 ) -> tuple[InferenceCycleResult, list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Returns (result, new_pending_instant, new_pending_online_non_instant, curr_signals_for_storage).
@@ -651,8 +654,12 @@ def evaluate_listing_transition(
     pending entry (adding a pending would cause an immediate relist-revert the next cycle
     because the seller is still present in curr_keys).
 
-    Non-instant rows that vanish while the seller was online (rule 4b) credit `likely_non_instant_online`;
-    pending entries allow a same-seller relist to decrement that credit.
+    Non-instant rows that vanish while the seller was online (rule 4b) defer for
+    `non_instant_online_grace_polls` cycles before crediting `likely_non_instant_online` (the
+    PoE trade `account.online` flag lags real logouts, so a same-seller reappearance within the
+    grace window is treated as `fetch_jitter_relist`, not a sale + revert pair). Once the grace
+    window elapses without a reappearance, the sale is credited and a pending entry with
+    `countedImmediate` stays open so a later same-seller relist can still decrement that credit.
 
     ``seller_online_probe``: optional map account name -> online bool from a live account search + fetch
     (poller). When present for a seller, overrides ``sellerOnline`` stored on the prior snapshot row.
@@ -663,6 +670,7 @@ def evaluate_listing_transition(
     pending_online = pending_online or []
     seller_online_probe = seller_online_probe or {}
     jitter_grace = max(0, int(fetch_jitter_grace_polls))
+    online_grace = max(0, int(non_instant_online_grace_polls))
 
     prev_keys = {(str(s["fingerprint"]), str(s["seller"])) for s in prev_signals}
     curr_keys = {(str(s["fingerprint"]), str(s["seller"])) for s in curr_signals}
@@ -683,10 +691,32 @@ def evaluate_listing_transition(
         price_currency = pend.get("priceCurrency")
         if not fp or not seller:
             continue
+        counted_imm = bool(pend.get("countedImmediate", True))
+        pend_grace = int(pend.get("jitterGracePolls") or 0)
+        polls_absent = max(0, cycle - removed)
         if (fp, seller) in curr_keys:
-            result.relist_same_seller += 1
-            result.likely_non_instant_online -= 1
             new_meta = _meta_for(curr_signals, fp, seller)
+            if not counted_imm and pend_grace > 0 and polls_absent <= pend_grace:
+                events.append(
+                    {
+                        "rule": "fetch_jitter_relist",
+                        "itemKey": item_key,
+                        "fingerprint": fp,
+                        "seller": seller,
+                        "mirrorEquiv": mirror_eq,
+                        "priceAmount": price_amount,
+                        "priceCurrency": price_currency,
+                        "newPriceAmount": new_meta.get("priceAmount") if new_meta else None,
+                        "newPriceCurrency": new_meta.get("priceCurrency") if new_meta else None,
+                        "pollsAbsent": polls_absent,
+                        "jitterGracePolls": pend_grace,
+                        "cycle": cycle,
+                    }
+                )
+                continue
+            result.relist_same_seller += 1
+            if counted_imm:
+                result.likely_non_instant_online -= 1
             events.append(
                 {
                     "rule": "relist_same_seller",
@@ -704,6 +734,27 @@ def evaluate_listing_transition(
             )
             continue
         if removed < cycle:
+            if counted_imm:
+                pass
+            elif pend_grace > 0 and polls_absent <= pend_grace:
+                new_pending_online.append(pend)
+                continue
+            else:
+                # Grace window elapsed with no reappearance; safe to credit the sale now.
+                result.likely_non_instant_online += 1
+                events.append(
+                    {
+                        "rule": "likely_non_instant_online_sale",
+                        "itemKey": item_key,
+                        "fingerprint": fp,
+                        "seller": seller,
+                        "mirrorEquiv": mirror_eq,
+                        "priceAmount": price_amount,
+                        "priceCurrency": price_currency,
+                        "cycle": cycle,
+                        "deferredCycles": polls_absent,
+                    }
+                )
             continue
         new_pending_online.append(pend)
 
@@ -959,24 +1010,43 @@ def evaluate_listing_transition(
                         }
                     )
                 else:
-                    result.likely_non_instant_online += 1
-                    events.append(
-                        {
-                            "rule": "likely_non_instant_online_sale",
-                            "itemKey": item_key,
-                            "fingerprint": fp,
-                            "seller": seller,
-                            "mirrorEquiv": mirror_eq,
-                            "priceAmount": price_amount,
-                            "priceCurrency": price_currency,
-                            "cycle": cycle,
-                        }
-                    )
+                    # Defer crediting for online_grace polls: PoE's account.online flag can lag a
+                    # real logout, so a quick same-seller reappearance is fetch jitter, not a sale.
+                    defer_for_online_jitter = online_grace > 0
+                    if not defer_for_online_jitter:
+                        result.likely_non_instant_online += 1
+                        events.append(
+                            {
+                                "rule": "likely_non_instant_online_sale",
+                                "itemKey": item_key,
+                                "fingerprint": fp,
+                                "seller": seller,
+                                "mirrorEquiv": mirror_eq,
+                                "priceAmount": price_amount,
+                                "priceCurrency": price_currency,
+                                "cycle": cycle,
+                            }
+                        )
+                    else:
+                        events.append(
+                            {
+                                "rule": "non_instant_online_removed_pending",
+                                "itemKey": item_key,
+                                "fingerprint": fp,
+                                "seller": seller,
+                                "mirrorEquiv": mirror_eq,
+                                "priceAmount": price_amount,
+                                "priceCurrency": price_currency,
+                                "cycle": cycle,
+                            }
+                        )
                     new_pending_online.append(
                         {
                             "fingerprint": fp,
                             "seller": seller,
                             "removed_cycle": cycle,
+                            "countedImmediate": not defer_for_online_jitter,
+                            "jitterGracePolls": online_grace if defer_for_online_jitter else 0,
                             "mirrorEquiv": mirror_eq,
                             "priceAmount": price_amount,
                             "priceCurrency": price_currency,

--- a/poller/test_sale_inference_engine.py
+++ b/poller/test_sale_inference_engine.py
@@ -189,5 +189,121 @@ class SaleInferenceEngineMultiListingCountDecreaseTests(unittest.TestCase):
         self.assertTrue(any(ev.get("rule") == "unlisted_above_baseline" for ev in result.events))
 
 
+class SaleInferenceEngineNonInstantOnlineGraceTests(unittest.TestCase):
+    """Rule 4b: defer crediting a non-instant online vanish so a quick relist isn't a false sale."""
+
+    def _prev_signal(self, seller: str = "seller1") -> dict:
+        return {
+            "fingerprint": "fp1",
+            "seller": seller,
+            "isInstant": False,
+            "mirrorEquiv": 5.0,
+            "priceAmount": 5.0,
+            "priceCurrency": "mirror",
+        }
+
+    def test_vanish_defers_credit_when_grace_enabled(self) -> None:
+        """A non-instant online vanish holds as pending instead of crediting immediately."""
+        result, _, new_pending_online, _ = evaluate_listing_transition(
+            item_key="Item",
+            cycle=1,
+            prev_signals=[self._prev_signal()],
+            curr_signals=[],
+            pending_instant=[],
+            pending_online=[],
+            seller_online_probe={"seller1": True},
+            baseline_mirror=5.0,
+            non_instant_online_grace_polls=1,
+        )
+        self.assertEqual(result.likely_non_instant_online, 0)
+        self.assertFalse(any(ev.get("rule") == "likely_non_instant_online_sale" for ev in result.events))
+        self.assertTrue(any(ev.get("rule") == "non_instant_online_removed_pending" for ev in result.events))
+        self.assertEqual(len(new_pending_online), 1)
+        self.assertFalse(new_pending_online[0]["countedImmediate"])
+
+    def test_relist_within_grace_is_fetch_jitter_not_revert(self) -> None:
+        """A same-seller reappearance within the grace window is jitter, not a sale + revert pair."""
+        pending = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "removed_cycle": 1,
+                "countedImmediate": False,
+                "jitterGracePolls": 1,
+                "mirrorEquiv": 5.0,
+                "priceAmount": 5.0,
+                "priceCurrency": "mirror",
+            }
+        ]
+        result, _, new_pending_online, _ = evaluate_listing_transition(
+            item_key="Item",
+            cycle=2,
+            prev_signals=[],
+            curr_signals=[self._prev_signal()],
+            pending_instant=[],
+            pending_online=pending,
+            non_instant_online_grace_polls=1,
+        )
+        self.assertEqual(result.likely_non_instant_online, 0)
+        self.assertEqual(result.relist_same_seller, 0)
+        self.assertTrue(any(ev.get("rule") == "fetch_jitter_relist" for ev in result.events))
+        self.assertEqual(len(new_pending_online), 0)
+
+    def test_credit_after_grace_elapses_without_reappearance(self) -> None:
+        """No reappearance within the grace window credits the sale on the next cycle."""
+        pending = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "removed_cycle": 1,
+                "countedImmediate": False,
+                "jitterGracePolls": 1,
+                "mirrorEquiv": 5.0,
+                "priceAmount": 5.0,
+                "priceCurrency": "mirror",
+            }
+        ]
+        result, _, new_pending_online, _ = evaluate_listing_transition(
+            item_key="Item",
+            cycle=3,
+            prev_signals=[],
+            curr_signals=[],
+            pending_instant=[],
+            pending_online=pending,
+            non_instant_online_grace_polls=1,
+        )
+        self.assertEqual(result.likely_non_instant_online, 1)
+        self.assertTrue(any(ev.get("rule") == "likely_non_instant_online_sale" for ev in result.events))
+        self.assertEqual(len(new_pending_online), 0)
+
+    def test_late_relist_after_credit_still_reverts(self) -> None:
+        """Once counted immediate (grace elapsed), a later relist still reverts the sale."""
+        pending = [
+            {
+                "fingerprint": "fp1",
+                "seller": "seller1",
+                "removed_cycle": 1,
+                "countedImmediate": True,
+                "jitterGracePolls": 0,
+                "mirrorEquiv": 5.0,
+                "priceAmount": 5.0,
+                "priceCurrency": "mirror",
+            }
+        ]
+        result, _, new_pending_online, _ = evaluate_listing_transition(
+            item_key="Item",
+            cycle=4,
+            prev_signals=[],
+            curr_signals=[self._prev_signal()],
+            pending_instant=[],
+            pending_online=pending,
+            non_instant_online_grace_polls=1,
+        )
+        self.assertEqual(result.likely_non_instant_online, -1)
+        self.assertEqual(result.relist_same_seller, 1)
+        self.assertTrue(any(ev.get("rule") == "relist_same_seller" for ev in result.events))
+        self.assertEqual(len(new_pending_online), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/storage/db.py
+++ b/storage/db.py
@@ -25,6 +25,7 @@ from .schema import (
     migration_014_new_item_alert_cooldown,
     migration_015_account_ban_alert_cooldown,
     migration_016_inference_signal_count,
+    migration_017_backfill_online_pending_counted_immediate,
 )
 
 
@@ -131,6 +132,7 @@ class Database:
             (14, migration_014_new_item_alert_cooldown()),
             (15, migration_015_account_ban_alert_cooldown()),
             (16, migration_016_inference_signal_count()),
+            (17, migration_017_backfill_online_pending_counted_immediate()),
         ]
 
         for version, sql in migrations:
@@ -154,6 +156,8 @@ class Database:
                 self._migration_013_inference_pending_jitter_grace(con)
             elif version == 16:
                 self._migration_016_inference_signal_count(con)
+            elif version == 17:
+                self._migration_017_backfill_online_pending_counted_immediate(con)
             elif sql.strip():
                 con.executescript(sql)
             con.execute(
@@ -422,6 +426,23 @@ class Database:
             UPDATE inference_state_signals
                SET signal_count = 1
              WHERE signal_count IS NULL OR signal_count < 1
+            """
+        )
+
+    def _migration_017_backfill_online_pending_counted_immediate(self, con: sqlite3.Connection) -> None:
+        """
+        Pre-fix pending `online_non_instant` rows were always credited immediately (rule 4b had no
+        jitter-grace deferral), but were persisted with `counted_immediate = 0` (the field wasn't set
+        yet). Mark still-open rows with `jitter_grace_polls = 0` as `counted_immediate = 1` so the new
+        deferral-aware resolution logic doesn't double-credit or skip their revert decrement.
+        """
+        con.execute(
+            """
+            UPDATE inference_state_pending
+               SET counted_immediate = 1
+             WHERE pending_kind = 'online_non_instant'
+               AND jitter_grace_polls = 0
+               AND counted_immediate = 0
             """
         )
 

--- a/storage/schema.py
+++ b/storage/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 
 def migration_001_initial() -> str:
@@ -322,5 +322,10 @@ CREATE INDEX IF NOT EXISTS idx_inference_events_rule ON inference_events(rule);
 
 
 def migration_016_inference_signal_count() -> str:
+    """Applied via a Python idempotent migration in `storage/db.py`."""
+    return ""
+
+
+def migration_017_backfill_online_pending_counted_immediate() -> str:
     """Applied via a Python idempotent migration in `storage/db.py`."""
     return ""


### PR DESCRIPTION
Non-instant listings that vanish while the seller appears online were being credited as `likely_non_instant_online_sale` immediately, then often reverted ~1 poll cycle later via relist_same_seller. DB analysis showed a ~65% revert rate, with most reverts landing almost exactly one poll cycle after the "sale" — consistent with sellers briefly logging off rather than actual sales, compounded by lag in PoE trade's `account.online` flag.

- sale_inference_engine.py: add `non_instant_online_grace_polls` grace window (default 1) before crediting rule 4b; a same-seller relist within the window now resolves as a silent `fetch_jitter_relist` instead of a sale+revert alert pair.
- poll_item_prices.py: load new config key `inference_non_instant_online_grace_polls` and thread it through.
- storage/schema.py, storage/db.py: bump schema to v17, add migration to backfill already-open `online_non_instant` pending rows as counted-immediate so in-flight rows don't get double-credited or miss their revert across the deploy.
- test_sale_inference_engine.py: cover defer-on-vanish, jitter-relist within grace, credit-after-grace-elapses, and late revert after credit.